### PR TITLE
fix: Handle the argument passed because of a space break

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/shafreeck/cortana
+module github.com/liwenson/cortana
 
-go 1.14
+go 1.17
 
 require github.com/google/btree v1.0.0


### PR DESCRIPTION
Preserve the integrity of the parameter by enclosing it with []